### PR TITLE
Feature/persist toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-Users have now the possibility to provide a custom HTML layout for the MessageToast content.
+## [3.0.0]
+
+- Added `persistToast`. Persists a single toast message to be unaffected by the regular timeout. Persited toast can only be closed by a user click event.
+- Added additional default stylings for toast message body. Default stylings can be overwritten as usual using `overwriteMessageAttributes`.
+  - `word-break: break-word;` Break long text in the message body
+  - `max-height: 250px; overflow: scroll;` Scrollable message body at a certain height
+- Removed `getOldestToast` and `popOldestToast` from the package
 
 ## [2.0.0]
+
+Users have now the possibility to provide a custom HTML layout for the MessageToast content.
 
 ### **BREAKING CHANGE**
 

--- a/elm.json
+++ b/elm.json
@@ -9,13 +9,10 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
-        "elm/browser": "1.0.0 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
         "elm/svg": "1.0.1 <= v < 2.0.0",
         "elm/time": "1.0.0 <= v < 2.0.0"
     },
-    "test-dependencies": {
-        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
-    }
+    "test-dependencies": {}
 }

--- a/examples/Configured.elm
+++ b/examples/Configured.elm
@@ -46,6 +46,7 @@ type Msg
     | ShowInfo
     | ShowSuccess
     | ShowWarning
+    | ShowPersisted
     | ShowSuperLong
     | ShowCustomView
     | UpdatedMessageToast (MessageToast Msg)
@@ -94,6 +95,16 @@ update msg model =
             in
             ( { model | messageToast = toast }, Cmd.none )
 
+        ShowPersisted ->
+            let
+                toast =
+                    model.messageToast
+                        |> MessageToast.warning
+                        |> MessageToast.persistToast
+                        |> MessageToast.withMessage "Error message won't disappear automatically."
+            in
+            ( { model | messageToast = toast }, Cmd.none )
+
         ShowSuperLong ->
             let
                 loremIpsum =
@@ -110,6 +121,8 @@ update msg model =
                         |> MessageToast.withMessage loremIpsum
             in
             ( { model | messageToast = toast }, Cmd.none )
+
+    
 
         ShowCustomView ->
             let
@@ -157,6 +170,7 @@ view model =
                 , th (thStyle ++ [ style "background-color" "gray" ]) [ text "INFO" ]
                 , th (thStyle ++ [ style "background-color" "lime" ]) [ text "SUCCESS" ]
                 , th (thStyle ++ [ style "background-color" "orange" ]) [ text "WARNING" ]
+                , th (thStyle ++ [ style "background-color" "red" ]) [ text "PERSISTED WARNING" ]
                 , th (thStyle ++ [ style "background-color" "gray" ]) [ text "SUPERLONG" ]
                 , th (thStyle ++ [ style "background-color" "orange" ]) [ text "CUSTOM VIEW" ]
                 ]
@@ -166,6 +180,7 @@ view model =
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowInfo ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowSuccess ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowWarning ] [ text "Show" ] ]
+                , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowPersisted ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowSuperLong ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowCustomView ] [ text "Show" ] ]
                 ]

--- a/examples/Default.elm
+++ b/examples/Default.elm
@@ -48,6 +48,7 @@ type Msg
     | ShowInfo
     | ShowSuccess
     | ShowWarning
+    | ShowPersisted
     | ShowSuperLong
     | ShowCustomView
     | UpdatedMessageToast (MessageToast Msg)
@@ -93,6 +94,16 @@ update msg model =
                     model.messageToast
                         |> MessageToast.warning
                         |> MessageToast.withMessage "Could not create entity."
+            in
+            ( { model | messageToast = toast }, Cmd.none )
+
+        ShowPersisted ->
+            let
+                toast =
+                    model.messageToast
+                        |> MessageToast.warning
+                        |> MessageToast.persistToast
+                        |> MessageToast.withMessage "Error message won't disappear automatically."
             in
             ( { model | messageToast = toast }, Cmd.none )
 
@@ -155,6 +166,7 @@ view model =
                 , th (thStyle ++ [ style "background-color" "gray" ]) [ text "INFO" ]
                 , th (thStyle ++ [ style "background-color" "lime" ]) [ text "SUCCESS" ]
                 , th (thStyle ++ [ style "background-color" "orange" ]) [ text "WARNING" ]
+                , th (thStyle ++ [ style "background-color" "red" ]) [ text "PERSISTED WARNING" ]
                 , th (thStyle ++ [ style "background-color" "gray" ]) [ text "SUPERLONG" ]
                 , th (thStyle ++ [ style "background-color" "orange" ]) [ text "CUSTOM VIEW" ]
                 ]
@@ -164,6 +176,7 @@ view model =
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowInfo ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowSuccess ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowWarning ] [ text "Show" ] ]
+                , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowPersisted ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowSuperLong ] [ text "Show" ] ]
                 , td [ style "background-color" "#ddd", style "text-align" "center" ] [ button [ onClick <| ShowCustomView ] [ text "Show" ] ]
                 ]

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -1,0 +1,26 @@
+{
+    "type": "application",
+    "source-directories": [
+        "../src",
+        "."
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm/svg": "1.0.1",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/src/MessageToast.elm
+++ b/src/MessageToast.elm
@@ -71,6 +71,10 @@ type MessageToast msg
     = MessageToast (ToastConfig msg) (List (ToastMessage msg))
 
 
+type IntermediateMessageToast msg
+    = Intermediate ( ToastMessage msg, MessageToast msg )
+
+
 {-| Defines the content type of a toast.
 
     Undefined -> No display type defined, nothing will be displayed
@@ -167,30 +171,30 @@ initWithConfig updateMsg customConfig =
 
 {-| Generates a dangerous message toast.
 -}
-danger : MessageToast msg -> ( ToastMessage msg, MessageToast msg )
+danger : MessageToast msg -> IntermediateMessageToast msg
 danger messageToast =
-    Tuple.pair { defaultToastMessage | toastType = Danger } messageToast
+    Intermediate <| Tuple.pair { defaultToastMessage | toastType = Danger } messageToast
 
 
 {-| Generates an informative message toast.
 -}
-info : MessageToast msg -> ( ToastMessage msg, MessageToast msg )
+info : MessageToast msg -> IntermediateMessageToast msg
 info messageToast =
-    Tuple.pair { defaultToastMessage | toastType = Info } messageToast
+    Intermediate <| Tuple.pair { defaultToastMessage | toastType = Info } messageToast
 
 
 {-| Generates a success message toast.
 -}
-success : MessageToast msg -> ( ToastMessage msg, MessageToast msg )
+success : MessageToast msg -> IntermediateMessageToast msg
 success messageToast =
-    Tuple.pair { defaultToastMessage | toastType = Success } messageToast
+    Intermediate <| Tuple.pair { defaultToastMessage | toastType = Success } messageToast
 
 
 {-| Generates a warning message toast.
 -}
-warning : MessageToast msg -> ( ToastMessage msg, MessageToast msg )
+warning : MessageToast msg -> IntermediateMessageToast msg
 warning messageToast =
-    Tuple.pair { defaultToastMessage | toastType = Warning } messageToast
+    Intermediate <| Tuple.pair { defaultToastMessage | toastType = Warning } messageToast
 
 
 
@@ -200,9 +204,9 @@ warning messageToast =
 {-| Keeps the toast persisted in the MessageToast container by making it unaffected to
 the defined toast-timeout. The toast can still be removed by user clicks.
 -}
-persistToast : ( ToastMessage msg, MessageToast msg ) -> ( ToastMessage msg, MessageToast msg )
-persistToast ( toastMessage, messageToast ) =
-    ( { toastMessage | persisted = True }, messageToast )
+persistToast : IntermediateMessageToast msg -> IntermediateMessageToast msg
+persistToast (Intermediate ( toastMessage, messageToast )) =
+    Intermediate <| ( { toastMessage | persisted = True }, messageToast )
 
 
 
@@ -211,15 +215,15 @@ persistToast ( toastMessage, messageToast ) =
 
 {-| Displays a generated MessageToast content with a given message in the default layout.
 -}
-withMessage : String -> ( ToastMessage msg, MessageToast msg ) -> MessageToast msg
-withMessage message ( content, toast ) =
+withMessage : String -> IntermediateMessageToast msg -> MessageToast msg
+withMessage message (Intermediate ( content, toast )) =
     appendToList { content | content = Message message } toast
 
 
 {-| Displays a generated MessageToast content with a given user-defined layout.
 -}
-withHtml : Html msg -> ( ToastMessage msg, MessageToast msg ) -> MessageToast msg
-withHtml userDefinedView ( content, toast ) =
+withHtml : Html msg -> IntermediateMessageToast msg -> MessageToast msg
+withHtml userDefinedView (Intermediate ( content, toast )) =
     appendToList { content | content = View userDefinedView } toast
 
 

--- a/src/MessageToast.elm
+++ b/src/MessageToast.elm
@@ -356,6 +356,9 @@ viewToastMessage customMessageAttributes toast =
             [ class "toast-message"
             , style "padding" "0.75rem"
             , style "flex-grow" "1"
+            , style "word-break" "break-word"
+            , style "max-height" "250px"
+            , style "overflow" "scroll"
             ]
 
         updatedToastMessageAttributes =


### PR DESCRIPTION
closes #10 

- Added `persistToast`. Persists a single toast message to be unaffected by the regular timeout. Persited toast can only be closed by a user click event.
- Added additional default stylings for toast message body
  - `word-break: break-word;` Break long text in the message body
  - `max-height: 250px; overflow: scroll;` Scrollable message body at a certain height

Bumping to a new major version due to the styling changes. These might break the UI slightly if custom stylings have been used. Default stylings can be overwritten as usual using `overwriteMessageAttributes`.